### PR TITLE
add support for `peekTransferables` skipping data items that have a `…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ setInterval(() => {
 
 Trigger server event.
 
+Note: contents of data is recursively inspected for [Transferable objects](https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects). For large data, this can sometimes be intensive, so if an object contains an attribute `containsNoTransferables` that is set to `true`, transferable inspection (the `peekTransferables` function) will skip that object.
+
 ### WebRPC.Client
 
 #### `#constructor(options: { workers: Array<Worker> })`

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ export function isTransferable(object) {
 export function peekTransferables(data, result = []) {
   if (isTransferable(data)) {
     result.push(data)
-  } else if (isObject(data)) {
+  } else if (isObject(data) && !data.containsNoTransferables) {
     for (var i in data) {
       peekTransferables(data[i], result)
     }


### PR DESCRIPTION
…containsNoTransferables: true` data item