### PR TITLE
Convert fully to TS, add type exports 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "main": "dist/index.js",
   "module": "esm/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@librpc/ee": "1.0.4",
     "serialize-error": "^8.1.0"

--- a/src/declare.d.ts
+++ b/src/declare.d.ts
@@ -1,0 +1,10 @@
+declare module '@librpc/ee' {
+  export type Listener = (event: any) => void
+
+  export default class Emitter {
+    events: Record<'string', Listener[]>
+    on(event: string, listener: Listener): this
+    off(event: string, listener: Listener): this
+    emit(event: string, data: unknown): this
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import RpcClient from './client'
 import RpcServer from './server'
 
@@ -6,3 +5,5 @@ export default {
   Client: RpcClient,
   Server: RpcServer,
 }
+
+export type { RpcClient, RpcServer }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,18 @@
-//@ts-nocheck
-
 /**
  * Ensure that passed value is object
- * @param  {*}       object Value to check
- * @return {boolean}        Check result
+ * @param object Value to check
+ * @returns Check result
  */
-export function isObject(object) {
+export function isObject(object: any): object is Record<string, unknown> {
   return Object(object) === object
 }
 
 /**
  * Ensure that passed value could be transfer
- * @param  {*}       object Value to check
- * @return {boolean}        Check result
+ * @param object - Value to check
+ * @returns Check result
  */
-export function isTransferable(object) {
+export function isTransferable(object: any): object is Transferable {
   try {
     return (
       object instanceof ArrayBuffer ||
@@ -29,14 +27,14 @@ export function isTransferable(object) {
 
 /**
  * Recursively peek transferables from passed data
- * @param  {*}             data        Data source
+ * @param data - Data source
  * @param  {Array}         [result=[]] Dist array
- * @return {ArrayBuffer[]}             List of transferables objects
+ * @returns  List of transferables objects
  */
-export function peekTransferables(data, result = []) {
+export function peekTransferables(data: unknown, result: Transferable[] = []) {
   if (isTransferable(data)) {
     result.push(data)
-  } else if (isObject(data) && !data.containsNoTransferables) {
+  } else if (isObject(data) && !('containsNoTransferables' in data)) {
     for (var i in data) {
       peekTransferables(data[i], result)
     }
@@ -45,7 +43,7 @@ export function peekTransferables(data, result = []) {
 }
 
 /**
- * @return {string} Uniq uid
+ * @returns Uniq uid
  */
 export function uuid() {
   return Math.floor((1 + Math.random()) * 1e10).toString(16)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,13 @@
     "outDir": "dist",
     "target": "es2018",
     "types": ["node", "jest"],
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "esnext", "webworker"],
     "declaration": true,
     "moduleResolution": "node",
     "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
   }
 }


### PR DESCRIPTION
This repository already used TypeScript for compilation, this PR removes the `//@ts-nocheck`s, adds types everywhere, and exports them in the package.json. I did this to help me get the worker communication right in Apollo.